### PR TITLE
feat: require reference parameterisation for relative shelter volume

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADRIAIndicators"
 uuid = "05ad51df-066f-4748-8c47-f6b67db83211"
 authors = ["Daniel Tan"]
-version = "0.1.4"
+version = "0.2.0"
 
 [compat]
 julia = "1.11"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -66,7 +66,9 @@ ltmp_cover = ADRIAIndicators.ltmp_cover(relative_cover, habitable_area, reef_are
 
 # (b) Relative Shelter Volume
 # First, calculate 4D shelter volume, then aggregate to 2D [timesteps, locations].
-sv_4d = ADRIAIndicators.relative_shelter_volume(relative_cover, mean_colony_diameters, planar_area_params, habitable_area)
+# For the relative shelter volume, we provide a reference parameterisation.
+reference = (25.0, -8.31, 2.47) # (diam, intercept, coefficient)
+sv_4d = ADRIAIndicators.relative_shelter_volume(relative_cover, mean_colony_diameters, planar_area_params, habitable_area, reference)
 relative_shelter_volume = dropdims(sum(sv_4d, dims=(2, 3)), dims=(2, 3))
 
 # (c) Juvenile Indicator

--- a/src/cover_metrics.jl
+++ b/src/cover_metrics.jl
@@ -4,7 +4,7 @@
 Calculate the relative cover per location by summing over groups and size classes.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `out_relative_cover` : Output array buffer for relative cover with dimensions [timesteps ⋅ locations].
 """
 function relative_cover!(
@@ -24,7 +24,7 @@ end
 Calculate the relative cover per location by summing over groups and size classes.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 
 # Returns
 A 2D array of relative cover with dimensions [timesteps ⋅ locations].
@@ -43,7 +43,7 @@ end
 Calculate the relative taxa cover, summed up across all locations.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `location_area` : The coral habitable area for each location.
 - `out_relative_taxa_cover` : Output array buffer with dimensions [timesteps ⋅ groups].
 """
@@ -78,7 +78,7 @@ end
 Calculate the relative taxa cover, summed up across all locations.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `location_area` : The coral habitable area for each location.
 
 # Returns
@@ -108,7 +108,7 @@ end
 Calculate the relative taxa cover for each location.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `out_relative_loc_taxa_cover` : Output array buffer with dimensions [timesteps ⋅ groups ⋅ locations].
 """
 function relative_loc_taxa_cover!(
@@ -127,7 +127,7 @@ end
 Calculate the relative taxa cover for each location.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 
 # Returns
 A 3D array of relative taxa cover with dimensions [timesteps ⋅ groups ⋅ locations].

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -8,7 +8,7 @@ indicator. This is implementation is limited to using outputs that can be provid
 ecological models that only model corals.
 
 # Arguments
-- `ltmp_cover` : LTMP Coral Cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : LTMP Coral Cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `relative_shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `juvenile_indicator`: Juvenile Indicator with dimensions [timesteps ⋅ locations].
 - `out_rci` : Output RCI buffer with dimensions [timesteps ⋅ locations].
@@ -74,7 +74,7 @@ least two of the metrics condition criteria. The condition level is then assigne
 numerical value based on its categorisation.
 
 # Arguments
-- `ltmp_cover` : Relative Coral Cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : Relative Coral Cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `relative_shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `juvenile_indicator`: Relative juvenile cover with dimensions [timesteps ⋅ locations].
 
@@ -119,7 +119,7 @@ rubble. This is implementation is limited to using outputs that can be provided 
 ecological models that only model corals.
 
 # Arguments
-- `ltmp_cover` : LTMP Coral Cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : LTMP Coral Cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `relative_shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `juvenile_indicator`: Juvenile Indicator with dimensions [timesteps ⋅ locations].
 - `rubble` : Relative rubble cover with dimensions [timesteps ⋅ locations].
@@ -191,7 +191,7 @@ metrics condition criteria. The condition level is then assigned a numerical val
 its categorisation.
 
 # Arguments
-- `ltmp_cover` : Relative Coral Cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : Relative Coral Cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `relative_shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `juvenile_indicator`: Relative juvenile cover with dimensions [timesteps ⋅ locations].
 - `rubble` : Relative rubble cover with dimensions [timesteps ⋅ locations].
@@ -228,7 +228,7 @@ Calculate the Reef Biodiversity Condition Index (RBCI). This is implementation i
 using outputs that can be provided by coral ecology models.
 
 # Arguments
-- `rc` : Relative coral cover.
+- `rc` : Relative coral cover, relative to habitable area.
 - `cd` : Coral diversity.
 - `sv` : Relative shelter volume.
 - `out_rbci` : Output array buffer for the RCI.
@@ -259,7 +259,7 @@ This is implementation is limited to using outputs that can be provided by coral
 models.
 
 # Arguments
-- `relative_cover` : Relative coral cover.
+- `relative_cover` : Relative coral cover, relative to habitable area.
 - `coral_diversity` : Coral diversity.
 - `shelter_volume` : Relative shelter volume.
 
@@ -285,7 +285,7 @@ function reef_biodiversity_condition_index(
 end
 
 """
-    reef_tourism_index_no_rubble!(relative_cover::AbstractArray{T,2}, coral_evenness::AbstractArray{T,2}, relative_shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2}, out_rti::AbstractArray{T,2})::Nothing where {T<:AbstractFloat}
+    reef_tourism_index_no_rubble!(ltmp_cover::AbstractArray{T,2}, coral_evenness::AbstractArray{T,2}, relative_shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2}, out_rti::AbstractArray{T,2})::Nothing where {T<:AbstractFloat}
 
 Calculate the Reef Tourism Index (RTI) for a single scenario without rubble as input. This
 version of the RTI is for ecological models that do not model rubble.
@@ -293,14 +293,14 @@ version of the RTI is for ecological models that do not model rubble.
 This method uses four inputs: relative cover, coral evenness, relative shelter volume, and relative juveniles.
 
 # Arguments
-- `relative_cover` : Relative coral cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : Relative coral cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `coral_evenness` : Coral evenness with dimensions [timesteps ⋅ locations].
 - `relative_shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `relative_juveniles` : Relative juvenile cover with dimensions [timesteps ⋅ locations].
 - `out_rti` : Output array buffer for the RTI with dimensions [timesteps ⋅ locations].
 """
 function reef_tourism_index_no_rubble!(
-    relative_cover::AbstractArray{<:AbstractFloat,2},
+    ltmp_cover::AbstractArray{<:AbstractFloat,2},
     coral_evenness::AbstractArray{<:AbstractFloat,2},
     relative_shelter_volume::AbstractArray{<:AbstractFloat,2},
     relative_juveniles::AbstractArray{<:AbstractFloat,2},
@@ -314,7 +314,7 @@ function reef_tourism_index_no_rubble!(
     jv_coef = -0.0036065
 
     @. out_rti = intcp +
-        (rc_coef * relative_cover) +
+        (rc_coef * ltmp_cover) +
         (evenness_coef * coral_evenness) +
         (sv_coef * relative_shelter_volume) +
         (jv_coef * relative_juveniles)
@@ -325,7 +325,7 @@ function reef_tourism_index_no_rubble!(
 end
 
 """
-    reef_tourism_index_no_rubble(relative_cover::AbstractArray{T,2}, coral_evenness::AbstractArray{T,2}, relative_shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2})::AbstractArray{T,2} where {T<:AbstractFloat}
+    reef_tourism_index_no_rubble(ltmp_cover::AbstractArray{T,2}, coral_evenness::AbstractArray{T,2}, relative_shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2})::AbstractArray{T,2} where {T<:AbstractFloat}
 
 Calculate the Reef Tourism Index (RTI) for a single scenario, without rubble as input. This
 version of the RTI is for ecological models that do not model rubble.
@@ -335,7 +335,7 @@ This method uses four inputs: relative cover, coral evenness, relative shelter v
 The RTI is a continuous version of the Reef Condition Index, fitted with a linear regression model.
 
 # Arguments
-- `relative_cover` : Relative coral cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : Relative coral cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `coral_evenness` : Coral evenness with dimensions [timesteps ⋅ locations].
 - `relative_shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `relative_juveniles` : Relative juvenile cover with dimensions [timesteps ⋅ locations].
@@ -344,19 +344,19 @@ The RTI is a continuous version of the Reef Condition Index, fitted with a linea
 A 2D array of the Reef Tourism Index with dimensions [timesteps ⋅ locations].
 """
 function reef_tourism_index_no_rubble(
-    relative_cover::AbstractArray{<:AbstractFloat,2},
+    ltmp_cover::AbstractArray{<:AbstractFloat,2},
     coral_evenness::AbstractArray{<:AbstractFloat,2},
     relative_shelter_volume::AbstractArray{<:AbstractFloat,2},
     relative_juveniles::AbstractArray{<:AbstractFloat,2}
 )::AbstractArray{<:AbstractFloat,2}
-    rc_size = size(relative_cover)
+    rc_size = size(ltmp_cover)
     if (rc_size != size(coral_evenness)) || (rc_size != size(relative_shelter_volume)) || (rc_size != size(relative_juveniles))
         throw(DimensionMismatch("All input metric arrays must have the same dimensions."))
     end
 
     out_rti = zeros(Float64, rc_size)
     reef_tourism_index_no_rubble!(
-        relative_cover,
+        ltmp_cover,
         coral_evenness,
         relative_shelter_volume,
         relative_juveniles,
@@ -367,21 +367,21 @@ function reef_tourism_index_no_rubble(
 end
 
 """
-    reef_tourism_index!(relative_cover::AbstractArray{T,2}, shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2}, rubble::AbstractArray{T,2}, out_rti::AbstractArray{T,2})::Nothing where {T<:AbstractFloat}
+    reef_tourism_index!(ltmp_cover::AbstractArray{T,2}, shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2}, rubble::AbstractArray{T,2}, out_rti::AbstractArray{T,2})::Nothing where {T<:AbstractFloat}
 
 Calculate the Reef Tourism Index (RTI) for a single scenario.
 
 This method uses four inputs: relative cover, shelter volume, relative juveniles, and rubble.
 
 # Arguments
-- `relative_cover` : Relative coral cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : Relative coral cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `relative_juveniles` : Relative juvenile cover with dimensions [timesteps ⋅ locations].
 - `rubble` : Rubble as a proportion of location area with dimensions [timesteps ⋅ locations].
 - `out_rti` : Output array buffer for the RTI with dimensions [timesteps ⋅ locations].
 """
 function reef_tourism_index!(
-    relative_cover::AbstractArray{<:AbstractFloat,2},
+    ltmp_cover::AbstractArray{<:AbstractFloat,2},
     shelter_volume::AbstractArray{<:AbstractFloat,2},
     relative_juveniles::AbstractArray{<:AbstractFloat,2},
     rubble::AbstractArray{<:AbstractFloat,2},
@@ -395,7 +395,7 @@ function reef_tourism_index!(
     rubble_coef = 0.7764
 
     @. out_rti = intcp +
-        (rc_coef * relative_cover) +
+        (rc_coef * ltmp_cover) +
         (sv_coef * shelter_volume) +
         (jv_coef * relative_juveniles) +
         (rubble_coef * ( 1 - rubble))
@@ -406,7 +406,7 @@ function reef_tourism_index!(
 end
 
 """
-    reef_tourism_index(relative_cover::AbstractArray{T,2}, shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2}, rubble::AbstractArray{T,2})::AbstractArray{T,2} where {T<:AbstractFloat}
+    reef_tourism_index(ltmp_cover::AbstractArray{T,2}, shelter_volume::AbstractArray{T,2}, relative_juveniles::AbstractArray{T,2}, rubble::AbstractArray{T,2})::AbstractArray{T,2} where {T<:AbstractFloat}
 
 Calculate the Reef Tourism Index (RTI) for a single scenario. The RTI is the Reef
 Condition Index made continuous by fitting a linear regression model using relative cover,
@@ -415,7 +415,7 @@ shelter volume, relative juveniles, and rubble to underpin it.
 This method uses four inputs: relative cover, shelter volume, relative juveniles, and rubble.
 
 # Arguments
-- `relative_cover` : Relative Coral Cover with dimensions [timesteps ⋅ locations].
+- `ltmp_cover` : Relative Coral Cover with dimensions [timesteps ⋅ locations], relative to reef area.
 - `shelter_volume` : Relative shelter volume with dimensions [timesteps ⋅ locations].
 - `relative_juveniles` : Relative juvenile cover with dimensions [timesteps ⋅ locations].
 - `rubble` : Rubble as proportion of location area with dimensions [timesteps ⋅ locations].
@@ -424,19 +424,19 @@ This method uses four inputs: relative cover, shelter volume, relative juveniles
 A 2D array of the Reef Tourism Index with dimensions [timesteps ⋅ locations].
 """
 function reef_tourism_index(
-    relative_cover::AbstractArray{<:AbstractFloat,2},
+    ltmp_cover::AbstractArray{<:AbstractFloat,2},
     shelter_volume::AbstractArray{<:AbstractFloat,2},
     relative_juveniles::AbstractArray{<:AbstractFloat,2},
     rubble::AbstractArray{<:AbstractFloat,2}
 )::AbstractArray{<:AbstractFloat,2}
-    rc_size = size(relative_cover)
+    rc_size = size(ltmp_cover)
     if (rc_size != size(shelter_volume)) || (rc_size != size(relative_juveniles)) || (rc_size != size(rubble))
         throw(DimensionMismatch("All input metric arrays must have the same dimensions."))
     end
 
-    out_rti = zeros(eltype(relative_cover), rc_size)
+    out_rti = zeros(eltype(ltmp_cover), rc_size)
     reef_tourism_index!(
-        relative_cover, shelter_volume, relative_juveniles, rubble, out_rti
+        ltmp_cover, shelter_volume, relative_juveniles, rubble, out_rti
     )
 
     return out_rti
@@ -448,7 +448,7 @@ end
 Calculate the Reef Fish Index (RFI) for a single scenario.
 
 # Arguments
-- `rc` : Relative coral cover with dimensions [timesteps ⋅ locations].
+- `rc` : Relative coral cover with dimensions [timesteps ⋅ locations], relative to habitable area.
 - `out_rfi` : Output array buffer for the RFI with dimensions [timesteps ⋅ locations].
 """
 function reef_fish_index!(
@@ -478,7 +478,7 @@ Graham et al., 2013 [1]. RFI (kg/km²) as a functional of relative cover (``x``)
 where SC is the structural complexity of the location.
 
 # Arguments
-- `relative_cover` : Relative coral cover with dimensions [timesteps ⋅ locations].
+- `relative_cover` : Relative coral cover with dimensions [timesteps ⋅ locations], relative to habitable area.
 
 # Returns
 A 2D array of the Reef Fish Index with dimensions [timesteps ⋅ locations].

--- a/src/juvenile_metrics.jl
+++ b/src/juvenile_metrics.jl
@@ -4,7 +4,7 @@
 Calculate the relative coral cover composed of juveniles.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 - `out_relative_juveniles` : Output array buffer with dimensions [timesteps ⋅ locations].
 """
@@ -27,7 +27,7 @@ Calculate the relative coral cover composed of juveniles for a 5-dimensional arr
 cover.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 - `out_relative_juveniles` : Output array buffer with dimensions [timesteps ⋅ locations ⋅ scenarios].
 """
@@ -52,7 +52,7 @@ end
 Calculate the relative coral cover composed of juveniles.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 
 # Returns
@@ -83,7 +83,7 @@ Calculate the relative coral cover composed of juveniles for a 5-dimensional arr
 cover.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 
 # Returns
@@ -114,7 +114,7 @@ Calculate the relative coral cover composed of juveniles over time and functiona
 Returns the output into a preallocated buffer.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 - `location_area` : Vector containing the area of each location with dimensions [locations].
 - `out_relative_taxa_juveniles` : Output array buffer with dimensions [timesteps ⋅ groups].
@@ -152,7 +152,7 @@ end
 Calculate the relative coral cover composed of juveniles over time and functional group.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 - `location_area` : Vector containing the area of each location with dimensions [locations].
 
@@ -180,7 +180,7 @@ Calculate the relative coral cover copmosed of juveniles over time, functional g
 location. Returns the output into a preallocated buffer
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 - `out_relative_taxa_juveniles` : Output array buffer with dimensions [timesteps ⋅ groups ⋅ locations].
 """
@@ -202,7 +202,7 @@ Calculate the relative coral cover composed of juveniles over time, functional g
 location.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 
 # Returns
@@ -227,7 +227,7 @@ end
 Calculate the absolute coral cover composed of juveniles for each timestep and location.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : A boolean vector indicating which size classes are juvenile.
 - `location_area` : Habitable area for each location.
 - `out_absolute_juveniles` : Output array buffer with dimensions [timesteps ⋅ locations].
@@ -250,7 +250,7 @@ end
 Calculate the absolute coral cover composed of juveniles for each timestep, location, and scenario.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `location_area` : Habitable area for each location.
 - `out_absolute_juveniles` : Output array buffer with dimensions [timesteps ⋅ locations ⋅ scenarios].
@@ -278,7 +278,7 @@ end
 Calculate the absolute coral cover composed of juveniles for each timestep and location.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `location_area` : Habitable area for each location.
 
@@ -310,7 +310,7 @@ end
 Calculate the absolute coral cover composed of juveniles for each timestep, location, and scenario.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations ⋅ scenarios], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `location_area` : Habitable area for each location.
 
@@ -343,7 +343,7 @@ Calculate the coral cover occupied by juveniles over timesteps and functional gr
 results in a preallocated buffer.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `location_area` : Habitable area for each location.
 - `out_absolute_taxa_juveniles` : Out array buffer with dimensions [timesteps ⋅ groups ⋅ locations]
@@ -381,7 +381,7 @@ Calculate the coral cover occupied by juveniles in absolute units over timesteps
 groups and locations.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `location_area` : Habitable area for each location.
 
@@ -409,7 +409,7 @@ Calculate the coral cover occupied by juveniles in absolute units over timesteps
 groups and locations. Write results into a preallocated buffer.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `location_area` : Habitable area for each location.
 - `out_absolute_loc_taxa_juveniles` : Out array buffer with dimensions [timesteps ⋅ groups ⋅ locations]
@@ -447,7 +447,7 @@ Calculate the coral cover occupied by juveniles in absolute units over timesteps
 groups and locations.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `location_area` : Habitable area for each location.
 
@@ -500,7 +500,7 @@ Indicator for juvenile density (0 - 1) where 1 indicates the maximum theoretical
 juveniles have been achieved.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations]
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating juvenile size classes.
 - `habitable_area` : Available area habitable by coral for each location.
 - `mean_colony_diameters` : Mean colony diameter for each group and size class with dimensions [groups ⋅ size classes]
@@ -592,7 +592,7 @@ Then Juvenile Indicator (I) is given as,
 where ``H_A`` refers to habitable area and ``A(x; H_A)`` refers to absolute juvenile cover.
 
 # Arguments
-- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations]
+- `relative_cover` : Relative cover with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `is_juvenile` : Boolean mask indicating which sizes are juveniles.
 - `habitable_area` : Available area habitable by coral for each location.
 - `mean_colony_diameters` : Mean colony diameter for each group and size class with dimensions [groups ⋅ size classes]

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -208,6 +208,43 @@ function _colony_Lcm2_to_m3m2(
 end
 
 """
+    maximum_colony_volume(colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3})::T where {T<:AbstractFloat}
+
+Find the maximum colony volume per m² among all provided species and size classes.
+"""
+function maximum_colony_volume(
+    colony_mean_diam_cm::AbstractArray{T,2},
+    planar_area_params::AbstractArray{T,3}
+)::T where {T<:AbstractFloat}
+    max_vol::T = zero(T)
+    for idx in CartesianIndices(colony_mean_diam_cm)
+        v = _colony_Lcm2_to_m3m2(
+            colony_mean_diam_cm[idx],
+            planar_area_params[idx, 1],
+            planar_area_params[idx, 2]
+        )
+        if v > max_vol
+            max_vol = v
+        end
+    end
+
+    return max_vol
+end
+
+"""
+    maximum_colony_volume(diam::T, intercept::T, coefficient::T)::T where {T<:AbstractFloat}
+
+Calculate colony volume per m² for a specific parameterization.
+"""
+function maximum_colony_volume(
+    diam::T,
+    intercept::T,
+    coefficient::T
+)::T where {T<:AbstractFloat}
+    return _colony_Lcm2_to_m3m2(diam, intercept, coefficient)
+end
+
+"""
     absolute_shelter_volume!(rel_cover::AbstractArray{T,3}, colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3}, habitable_area::T, ASV::AbstractArray{T,3})::Nothing where {T<:AbstractFloat}
 
 # Arguments
@@ -307,10 +344,10 @@ function absolute_shelter_volume(
 end
 
 """
-    relative_shelter_volume!(rel_cover::AbstractArray{T,4}, colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3}, habitable_area_m²::AbstractVector{T}, out_RSV::AbstractArray{T,4})::Nothing where {T<:AbstractFloat}
+    relative_shelter_volume!(rel_cover::AbstractArray{T,4}, colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3}, habitable_area_m²::AbstractVector{T}, out_RSV::AbstractArray{T,4}, reference::Tuple{T, T, T})::Nothing where {T<:AbstractFloat}
 
 Calculate the relative shelter volume for a range of covers. Relative to the theoretical
-maximum of 50% cover of a coral species with the largest colony volume.
+maximum of 50% cover of a coral species with the specified reference parameterisation.
 Relative shelter volume (RSV) is given by
 
 ```math
@@ -327,31 +364,21 @@ where ASV and MSV are Absolute Shelter Volume and Maximum Shelter Volume respect
 - `planar_area_params` : Array containing the planar area parameters with dimensions [groups ⋅ sizes ⋅ (intercept, coefficient)].
 - `habitable_area_m²` : Habitable area in m² with dimensions [locations].
 - `out_RSV` : Output Relative shelter volume array buffer with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `reference` : Parameterisation to use as reference (mean diameter, intercept, coefficient).
 """
 function relative_shelter_volume!(
     rel_cover::AbstractArray{T,4},
     colony_mean_diam_cm::AbstractArray{T,2},
     planar_area_params::AbstractArray{T,3},
     habitable_area_m²::AbstractVector{T},
-    out_RSV::AbstractArray{T,4}
+    out_RSV::AbstractArray{T,4},
+    reference::Tuple{T, T, T}
 )::Nothing where {T<:AbstractFloat}
     n_groups, n_sizes = size(colony_mean_diam_cm)
     n_timesteps, _, _, n_locations = size(rel_cover)
 
-    # Calculate max colony volume per m²
-    max_colony_vol::T = zero(T)
-    for s in 1:n_sizes
-        for g in 1:n_groups
-            v = _colony_Lcm2_to_m3m2(
-                colony_mean_diam_cm[g, s],
-                planar_area_params[g, s, 1],
-                planar_area_params[g, s, 2]
-            )
-            if v > max_colony_vol
-                max_colony_vol = v
-            end
-        end
-    end
+    # Calculate max colony volume per m² from reference
+    max_colony_vol::T = _colony_Lcm2_to_m3m2(reference...)
 
     for l in 1:n_locations
         # Maximum shelter volume m³ = habitable_area * max_colony_vol * 0.5
@@ -378,7 +405,7 @@ function relative_shelter_volume!(
 end
 
 """
-    relative_shelter_volume(relative_cover::AbstractArray{T,4}, colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3}, habitable_area_m²::AbstractVector{T})::AbstractArray{T,4} where {T<:Real}
+    relative_shelter_volume(relative_cover::AbstractArray{T,4}, colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3}, habitable_area_m²::AbstractVector{T}, reference::Tuple{T, T, T})::AbstractArray{T,4} where {T<:Real}
 
 Calculate the relative shelter volume for a range of covers. Relative shelter volume (RSV) is
 given by
@@ -390,17 +417,17 @@ given by
 ```
 
 where ASV and MSV are Absolute Shelter Volume and Maximum Shelter Volume respectively.
-Previously, the maximum shelter volume has been defined by assuming the maximum theoretical
-shelter volume produced by the largest size class of Tabular Acropora. This function defines
-it by calculating the shelter volume for each functional group and size class and picking
-the maximum. For possible parametrisations of the log-log linear model used to
-predict shelter volume from planar area, see Urbina-Barreto et al., [1].
+The maximum shelter volume is defined by assuming the maximum theoretical shelter volume
+produced by a specified reference parameterisation at 50% cover.
+For possible parametrisations of the log-log linear model used to predict shelter volume
+from planar area, see Urbina-Barreto et al., [1].
 
 # Arguments
 - `rel_cover` : Relative Cover array with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `colony_mean_diam_cm` : Mean colony area per group and size class with dimensions [groups ⋅ sizes].
 - `planar_area_params` : Array containing the planar area parameters with dimensions [groups ⋅ sizes ⋅ (intercept, coefficient)].
 - `habitable_area_m²` : Habitable area in m² with dimensions [locations].
+- `reference` : Parameterisation to use as reference (mean diameter, intercept, coefficient).
 
 # Returns
 Relative shelter volume in an array with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations]
@@ -418,7 +445,8 @@ function relative_shelter_volume(
     relative_cover::AbstractArray{T,4},
     colony_mean_diam_cm::AbstractArray{T,2},
     planar_area_params::AbstractArray{T,3},
-    habitable_area_m²::AbstractVector{T}
+    habitable_area_m²::AbstractVector{T},
+    reference::Tuple{T, T, T}
 )::Array{T,4} where {T<:Real}
     n_tsteps::Int64, n_groups::Int64, n_sizes::Int64, n_locs::Int64 = size(relative_cover)
 
@@ -461,7 +489,12 @@ function relative_shelter_volume(
 
     RSV::Array{T,4} = zeros(T, n_tsteps, n_groups, n_sizes, n_locs)
     relative_shelter_volume!(
-        relative_cover, colony_mean_diam_cm, planar_area_params, habitable_area_m², RSV
+        relative_cover,
+        colony_mean_diam_cm,
+        planar_area_params,
+        habitable_area_m²,
+        RSV,
+        reference
     )
 
     return RSV

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -31,7 +31,7 @@ end
 Calculates coral taxa diversity as a dimensionless metric.
 
 # Arguments
-- `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations]
+- `r_taxa_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations], relative to habitable area.
 - `out_coral_diversity` : Output array buffer [timesteps ⋅ locations]
 """
 function coral_diversity!(
@@ -82,7 +82,7 @@ where ``x_g`` is the relative coral cover for the functional group, ``g``, and `
 total relative coral cover at the given location and timestep.
 
 # Arguments
-- `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations]
+- `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations], relative to habitable area.
 
 # Returns
 Matrix containing coral diversity metric of dimension [timesteps ⋅ locations]
@@ -102,7 +102,7 @@ Calculates evenness across functional coral groups in ADRIA as a diversity metri
 Inverse Simpsons diversity indicator.
 
 # Arguments
-- `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations]
+- `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations], relative to habitable area.
 - `out_coral_evenness` : Output array buffer [timesteps ⋅ locations]
 
 # References
@@ -154,7 +154,7 @@ E(x) = \\left(\\sum_{g=1}^{G}\\left(\\frac{x_g}{x_T} \\right)^2\\right)^{-1}
 ```
 
 # Arguments
-- `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations]
+- `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations], relative to habitable area.
 
 # Returns
 Matrix containing coral evenness metric of dimensions [timesteps ⋅ locations]
@@ -211,7 +211,7 @@ end
     absolute_shelter_volume!(rel_cover::AbstractArray{T,3}, colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3}, habitable_area::T, ASV::AbstractArray{T,3})::Nothing where {T<:AbstractFloat}
 
 # Arguments
-- `rel_cover` : 4-D Array of relative coral cover with dimensions [timesteps ⋅ groups ⋅ size ⋅ locations]
+- `rel_cover` : 4-D Array of relative coral cover with dimensions [timesteps ⋅ groups ⋅ size ⋅ locations], relative to habitable area.
 - `colony_mean_diam_cm` : Matrix of mean colony diameter with dimensions [groups ⋅ size]
 - `planar_area_params` : 3-D array of planar area parameters with dimensions [groups ⋅ size ⋅ (intercept, coefficient)]
 - `habitable_area_m2` : Vector of habitable area for each location [locations]
@@ -275,7 +275,7 @@ where ``ASV`` and ``A_C`` refers to absolute shelter volume and absolute coral c
 respectively.
 
 # Arguments
-- `rel_cover` : 4-D Array of relative coral cover with dimensions [timesteps ⋅ groups ⋅ size ⋅ locations]
+- `rel_cover` : 4-D Array of relative coral cover with dimensions [timesteps ⋅ groups ⋅ size ⋅ locations], relative to habitable area.
 - `colony_mean_diam_cm` : Matrix of mean colony diameter with dimensions [groups ⋅ size]
 - `planar_area_params` : 3-D array of planar area params with dimensions [groups ⋅ size ⋅ (intercept, coefficient)]
 - `habitable_area_m2` : Vector of habitable area for each location [locations]
@@ -322,7 +322,7 @@ Relative shelter volume (RSV) is given by
 where ASV and MSV are Absolute Shelter Volume and Maximum Shelter Volume respectively.
 
 # Arguments
-- `rel_cover` : Relative Cover array with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `rel_cover` : Relative Cover array with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `colony_mean_diam_cm` : Mean colony diameter per group and size class with dimensions [groups ⋅ sizes].
 - `planar_area_params` : Array containing the planar area parameters with dimensions [groups ⋅ sizes ⋅ (intercept, coefficient)].
 - `habitable_area_m²` : Habitable area in m² with dimensions [locations].
@@ -397,7 +397,7 @@ the maximum. For possible parametrisations of the log-log linear model used to
 predict shelter volume from planar area, see Urbina-Barreto et al., [1].
 
 # Arguments
-- `rel_cover` : Relative Cover array with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations].
+- `rel_cover` : Relative Cover array with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
 - `colony_mean_diam_cm` : Mean colony area per group and size class with dimensions [groups ⋅ sizes].
 - `planar_area_params` : Array containing the planar area parameters with dimensions [groups ⋅ sizes ⋅ (intercept, coefficient)].
 - `habitable_area_m²` : Habitable area in m² with dimensions [locations].

--- a/test/test_shelter_volume_metrics.jl
+++ b/test/test_shelter_volume_metrics.jl
@@ -91,7 +91,11 @@ end
     planar_area_params[:, :, 2] .= 1.0 # coefficient
 
     rsv = relative_shelter_volume(
-        relative_cover, colony_mean_diam_cm, planar_area_params, habitable_area
+        relative_cover,
+        colony_mean_diam_cm,
+        planar_area_params,
+        habitable_area,
+        (100.0, 0.0, 1.0)
     )
     agg_cover = sum(relative_cover, dims=(2, 3))
 
@@ -123,7 +127,11 @@ end
 
     msv = sv[1, 3] .* habitable_area .* 0.5
     rsv = relative_shelter_volume(
-        relative_cover, colony_mean_diam_cm, planar_area_params, habitable_area
+        relative_cover,
+        colony_mean_diam_cm,
+        planar_area_params,
+        habitable_area,
+        (25.0, -8.31, 2.47)
     )
     @test size(rsv) == (n_tsteps, n_groups, n_sizes, n_locs)
     @test all(


### PR DESCRIPTION
## Summary
  This PR modifies the relative_shelter_volume calculation to require an explicit reference parameterisation. Previously, the metric automatically identified the "maximum" shelter volume by scanning the
  provided species and size classes. This update gives users control over the normalization baseline, ensuring consistency across different datasets.

## Key Changes
   - API Change: relative_shelter_volume and relative_shelter_volume! now require a mandatory reference argument of type Tuple{T, T, T} (representing mean diameter, intercept, and coefficient).
   - New Helpers: Added maximum_colony_volume helper functions to src/metrics.jl for volume calculations.
   - Documentation: Updated docs/src/index.md with new usage examples.
   - Versioning: Bumped package version to 0.2.0 to signal a breaking change.

 ## Example Usage
```julia
# Define a reference (diameter, intercept, coefficient)
reference = (25.0, -8.31, 2.47)

# Calculate relative shelter volume
rsv = ADRIAIndicators.relative_shelter_volume(
   rel_cover,
   mean_diams,
   area_params,
   habitable_area,
   reference
)
```
 ## Breaking Change
  This is a breaking change. All existing calls to relative_shelter_volume must be updated to include the reference parameterisation tuple.