### PR TITLE
Fix Relative Shelter Volume reference calculation

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -377,10 +377,8 @@ function relative_shelter_volume!(
     n_groups, n_sizes = size(colony_mean_diam_cm)
     n_timesteps, _, _, n_locations = size(rel_cover)
 
-    # One reference coral per m²
-    prop_cov::Float64 = π * (reference[1] / (100.0 * 2.0))^2
-    # Calculate max colony volume per m² from reference
-    max_colony_vol::T = _colony_Lcm2_to_m3m2(reference...) * prop_cov
+    # Calculate max colony volume per m² from reference at 50% cover
+    max_colony_vol::T = _colony_Lcm2_to_m3m2(reference...) * 0.5
 
     for l in 1:n_locations
         # Maximum shelter volume m³ = habitable_area * max_colony_vol

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -347,7 +347,7 @@ end
     relative_shelter_volume!(rel_cover::AbstractArray{T,4}, colony_mean_diam_cm::AbstractArray{T,2}, planar_area_params::AbstractArray{T,3}, habitable_area_m²::AbstractVector{T}, out_RSV::AbstractArray{T,4}, reference::Tuple{T, T, T})::Nothing where {T<:AbstractFloat}
 
 Calculate the relative shelter volume for a range of covers. Relative to the theoretical
-maximum of 50% cover of a coral species with the specified reference parameterisation.
+maximum of one reference coral per m² with the specified reference parameterisation.
 Relative shelter volume (RSV) is given by
 
 ```math
@@ -377,8 +377,10 @@ function relative_shelter_volume!(
     n_groups, n_sizes = size(colony_mean_diam_cm)
     n_timesteps, _, _, n_locations = size(rel_cover)
 
-    # Calculate max colony volume per m² from reference at 50% cover
-    max_colony_vol::T = _colony_Lcm2_to_m3m2(reference...) * 0.5
+    # One reference coral per m²
+    prop_cov::Float64 = π * (reference[1] / (100.0 * 2.0))^2
+    # Calculate max colony volume per m² from reference
+    max_colony_vol::T = _colony_Lcm2_to_m3m2(reference...) * prop_cov
 
     for l in 1:n_locations
         # Maximum shelter volume m³ = habitable_area * max_colony_vol
@@ -416,14 +418,13 @@ given by
 ```
 
 where ASV and MSV are Absolute Shelter Volume and Maximum Shelter Volume respectively.
-The maximum shelter volume is defined by assuming the maximum theoretical shelter volume
-produced by a specified reference parameterisation at 50% cover.
+The maximum shelter volume is defined by assuming one reference colony per m².
 For possible parametrisations of the log-log linear model used to predict shelter volume
 from planar area, see Urbina-Barreto et al., [1].
 
 # Arguments
 - `rel_cover` : Relative Cover array with dimensions [timesteps ⋅ groups ⋅ sizes ⋅ locations], relative to habitable area.
-- `colony_mean_diam_cm` : Mean colony area per group and size class with dimensions [groups ⋅ sizes].
+- `colony_mean_diam_cm` : Mean colony diameter per group and size class with dimensions [groups ⋅ sizes].
 - `planar_area_params` : Array containing the planar area parameters with dimensions [groups ⋅ sizes ⋅ (intercept, coefficient)].
 - `habitable_area_m²` : Habitable area in m² with dimensions [locations].
 - `reference` : Parameterisation to use as reference (mean diameter, intercept, coefficient).

--- a/test/test_shelter_volume_metrics.jl
+++ b/test/test_shelter_volume_metrics.jl
@@ -97,12 +97,16 @@ end
         habitable_area,
         (100.0, 0.0, 1.0)
     )
-    agg_cover = sum(relative_cover, dims=(2, 3))
+    
+    # One reference coral per m²:
+    # diameter 100cm => radius 0.5m
+    # area = π * 0.5^2 = π * 0.25
+    prop_cov = π * 0.25
 
     @test all(rsv[1, :, :, 2] .≈ 0.0)
     @test all(rsv[2, :, :, 1] .≈ 0.0)
-    @test all(rsv[1, :, :, 1] .≈ relative_cover[1, :, :, 1] ./ 0.5)
-    @test all(rsv[2, :, :, 2] .≈ relative_cover[2, :, :, 2] ./ 0.5)
+    @test all(rsv[1, :, :, 1] .≈ relative_cover[1, :, :, 1] ./ prop_cov)
+    @test all(rsv[2, :, :, 2] .≈ relative_cover[2, :, :, 2] ./ prop_cov)
 
     colony_mean_diam_cm = [
         15.0 20.0 25.0;
@@ -125,7 +129,9 @@ end
     )
     sv .*= 0.001
 
-    msv = sv[1, 3] .* habitable_area .* 0.5
+    # MSV = sv[reference] * prop_cov * habitable_area
+    prop_cov = π * (25.0 / (100.0 * 2.0))^2
+    msv = sv[1, 3] .* habitable_area .* prop_cov
     rsv = relative_shelter_volume(
         relative_cover,
         colony_mean_diam_cm,


### PR DESCRIPTION
This PR aligns the `relative_shelter_volume!` implementation, docstrings, and unit tests with the single reference colony per m² standard.

### Changes
- **Implementation**: Reverted to calculating Maximum Shelter Volume (MSV) based on one reference colony per m² (using its projected area).
- **Documentation**: Updated docstrings to explicitly state the single-colony reference standard.
- **Verification**: Updated `test/test_shelter_volume_metrics.jl` to reflect the correct MSV calculation for both generic and specific parameterizations.