### PR TITLE
feat: normalize coral evenness metric

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -99,7 +99,7 @@ end
     coral_evenness!(r_taxa_cover::AbstractArray{T,3}, out_coral_evenness::Array{T,2})::Nothing where {T<:Real}
 
 Calculates evenness across functional coral groups in ADRIA as a diversity metric.
-Inverse Simpsons diversity indicator.
+Inverse Simpsons diversity indicator, normalized by the number of groups ``G`` to range between ``[0, 1]``.
 
 # Arguments
 - `rel_cover` : Relative Taxa Cover of dimensions [timesteps ⋅ groups ⋅ locations], relative to habitable area.
@@ -129,7 +129,7 @@ function coral_evenness!(
                 for g in 1:n_groups
                     sum_sq += (rel_cover[t, g, l] / loc_cover)^2
                 end
-                out_coral_evenness[t, l] = 1.0 / sum_sq
+                out_coral_evenness[t, l] = (1.0 / sum_sq) / n_groups
             else
                 out_coral_evenness[t, l] = 0.0
             end
@@ -143,13 +143,13 @@ end
     coral_evenness(r_taxa_cover::AbstractArray{T})::AbstractArray{T} where {T<:Real}
 
 Calculates evenness across functional coral groups in ADRIA as a diversity metric.
-Inverse Simpsons diversity indicator.
+Inverse Simpsons diversity indicator, normalized by the number of groups ``G`` to range between ``[0, 1]``.
 
 The coral evenness metric (E) is given as follows,
 
 ```math
 \\begin{align*}
-E(x) = \\left(\\sum_{g=1}^{G}\\left(\\frac{x_g}{x_T} \\right)^2\\right)^{-1}
+E(x) = \\frac{1}{G} \\left(\\sum_{g=1}^{G}\\left(\\frac{x_g}{x_T} \\right)^2\\right)^{-1}
 \\end{align*}
 ```
 

--- a/test/test_diversity_metrics.jl
+++ b/test/test_diversity_metrics.jl
@@ -98,9 +98,9 @@ end
 
         evenness = coral_evenness(rel_cover)
 
-        @test evenness[1, 1] ≈ 4.0
-        @test evenness[1, 2] ≈ (1 / 0.34375)
-        @test evenness[2, 1] ≈ 1.0
+        @test evenness[1, 1] ≈ 1.0
+        @test evenness[1, 2] ≈ (1 / 0.34375) / 4.0
+        @test evenness[2, 1] ≈ 0.25
         @test evenness[2, 2] == 0.0
 
         out_evenness = coral_evenness(rel_cover)


### PR DESCRIPTION
Changes:
1. **Implementation:** Modified `coral_evenness!` and `coral_evenness` in `src/metrics.jl` to divide the reciprocal Simpson's Index by the number of groups ($G$), scaling the range of evenness when coral is present from $[1.0, G]$ to $[\frac{1}{G}, 1.0]$.
2. **Documentation:** Updated docstrings and LaTeX math notation in `src/metrics.jl` to reflect this normalization step.
3. **Tests:** Updated existing test assertions in `test/test_diversity_metrics.jl` to match the new normalized outputs.